### PR TITLE
Use crypt module from commons and accept PEM

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -133,7 +133,7 @@ components:
 info:
   description: A service managing work packages for the GHGA CLI
   title: Work Package Service
-  version: 0.1.0
+  version: 0.1.1
 openapi: 3.0.2
 paths:
   /health:

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,10 +35,9 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    ghga-service-commons[api,auth]==0.2.1
+    ghga-service-commons[api,auth,crypt]==0.3.0
     ghga-event-schemas==0.10.1
     hexkit[akafka,mongodb]==0.9.2
-    pynacl==1.5
     httpx==0.23.3
     typer==0.7.0
 

--- a/tests/fixtures/crypt.py
+++ b/tests/fixtures/crypt.py
@@ -14,22 +14,19 @@
 # limitations under the License.
 #
 
-import base64
+from ghga_service_commons.utils.crypt import decrypt as decrypt_with_key
+from ghga_service_commons.utils.crypt import encode_key, generate_key_pair
 
-from nacl.public import PrivateKey, SealedBox
+__all__ = [
+    "decrypt",
+    "user_public_crypt4gh_key",
+]
 
-__all__ = ["user_crypt4gh_key_pair", "user_public_crypt4gh_key"]
+user_crypt4gh_key_pair = generate_key_pair()
 
-user_crypt4gh_key_pair = PrivateKey.generate()
-
-user_public_crypt4gh_key = base64.b64encode(
-    bytes(user_crypt4gh_key_pair.public_key)
-).decode("ascii")
+user_public_crypt4gh_key = encode_key(user_crypt4gh_key_pair.public)
 
 
-def decrypt(encrypted_data: str) -> str:
+def decrypt(data: str) -> str:
     """Decrypt a str of base64 encoded ASCII data."""
-    unseal_box = SealedBox(user_crypt4gh_key_pair)
-    encrypted_bytes = base64.b64decode(encrypted_data)
-    decrypted_bytes = unseal_box.decrypt(encrypted_bytes)
-    return decrypted_bytes.decode("ascii")
+    return decrypt_with_key(data, user_crypt4gh_key_pair.private)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -57,6 +57,22 @@ def test_good_creation_data():
     assert data.file_ids == ["some-file-id", "another-file-id"]
     assert data.user_public_crypt4gh_key == user_public_crypt4gh_key
 
+    wrapped_key = (
+        "\n\n-----BEGIN CRYPT4GH PUBLIC KEY-----\n"
+        + user_public_crypt4gh_key
+        + "\n-----END CRYPT4GH PUBLIC KEY-----\n\n"
+    )
+    data = WorkPackageCreationData(
+        dataset_id="123-foo-456",
+        type=WorkType.UPLOAD,
+        file_ids=None,
+        user_public_crypt4gh_key=wrapped_key,
+    )
+    assert data.dataset_id == "123-foo-456"
+    assert data.type == WorkType.UPLOAD
+    assert data.file_ids is None
+    assert data.user_public_crypt4gh_key == user_public_crypt4gh_key
+
 
 def test_bad_creation_data():
     """Test instantiating invalid work package creation DTO."""

--- a/wps/__init__.py
+++ b/wps/__init__.py
@@ -15,4 +15,4 @@
 
 """Work package manager"""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/wps/core/models.py
+++ b/wps/core/models.py
@@ -22,7 +22,7 @@ from typing import Optional
 from ghga_service_commons.utils.utc_dates import DateTimeUTC
 from pydantic import BaseModel, EmailStr, Field, validator
 
-from wps.core.crypt import decode_public_key
+from wps.core.crypt import validate_public_key
 
 __all__ = [
     "WorkType",
@@ -96,8 +96,7 @@ class WorkPackageCreationData(BaseDto):
     @validator("user_public_crypt4gh_key")
     def user_public_crypt4gh_key_valid(cls, key):  # pylint: disable=no-self-argument
         """Validate the user's public Crypt4GH key."""
-        decode_public_key(key)
-        return key
+        return validate_public_key(key)
 
 
 class WorkPackageCreationResponse(BaseModel):

--- a/wps/core/repository.py
+++ b/wps/core/repository.py
@@ -20,11 +20,11 @@ from datetime import timedelta
 from typing import Optional
 
 from ghga_service_commons.auth.ghga import AuthContext
+from ghga_service_commons.utils.crypt import encrypt
 from ghga_service_commons.utils.utc_dates import now_as_utc
 from jwcrypto import jwk
 from pydantic import BaseSettings, Field, SecretStr
 
-from wps.core.crypt import encrypt
 from wps.core.models import (
     Dataset,
     WorkOrderToken,


### PR DESCRIPTION
This PR refactors the use of crypt functions in WPS:

- Instead of using pynacl directly, use the functions from the GHGA service commons lib.
- When validating the public key, allow passing a string in PEM format with wrapper lines.