### PR TITLE
Do not inherit from KeyError

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   app:
     build:

--- a/src/wps/ports/inbound/repository.py
+++ b/src/wps/ports/inbound/repository.py
@@ -32,10 +32,10 @@ from wps.core.models import (
 class WorkPackageRepositoryPort(ABC):
     """A repository for work packages."""
 
-    class WorkPackageAccessError(KeyError):
+    class WorkPackageAccessError(RuntimeError):
         """Error that is raised when a work package cannot be accessed."""
 
-    class DatasetNotFoundError(KeyError):
+    class DatasetNotFoundError(RuntimeError):
         """Error that is raised when a dataset does not exist."""
 
     @abstractmethod


### PR DESCRIPTION
The errors used in the `WorkPackageRepositoryPort` inherited from KeyError, because the repository lookup somewhat resembles a dictionary lookup. However, the arg of the KeyError is considered to be the problematic key, not the message, and therefore rendered using repr. This caused the errors to be passed to the client with additional single quotes. By sub-classing from RunimeError instead, we avoid this problem.