### PR TITLE
Enable the DLQ

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -12,6 +12,7 @@ db_name: "dev-db"
 
 service_instance_id: 'wps_1'
 kafka_servers: ["kafka:9092"]
+kafka_enable_dlq: True
 
 download_access_url: "http://127.0.0.1:8080/download-access"
 

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -24,7 +24,7 @@ download_access_url: http://127.0.0.1:8080/download-access
 generate_correlation_id: true
 host: 127.0.0.1
 kafka_dlq_topic: dlq
-kafka_enable_dlq: false
+kafka_enable_dlq: true
 kafka_max_message_size: 1048576
 kafka_max_retries: 0
 kafka_retry_backoff: 0

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -99,7 +99,7 @@ def fixture_config(kafka: KafkaFixture, mongodb: MongoDbFixture) -> Config:
         auth_key=AUTH_KEY_PAIR.export_public(),  # pyright: ignore
         download_access_url="http://access",
         work_package_signing_key=SIGNING_KEY_PAIR.export_private(),  # pyright: ignore
-        **kafka.config.model_dump(),
+        **kafka.config.model_dump(exclude={"kafka_enable_dlq"}),
         **mongodb.config.model_dump(),
     )
 


### PR DESCRIPTION
Adds 2 tests to `test_events.py` to make sure that failed inbound events get published to the DLQ and that events from the retry topic get consumed correctly.