### PR TITLE
Use FileAccessionMappings again

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -20,7 +20,7 @@ research_data_upload_box_topic: upload-boxes
 dataset_change_topic: metadata-datasets
 dataset_upsertion_type: dataset_created
 dataset_deletion_type: dataset_deleted
-alt_accession_topic: alt-accessions
+accession_map_topic: file-accession-mappings
 
 # the default keys are invalid but set for creating the example specs
 auth_key: "{}"

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The service requires the following configuration parameters:
 - <a id="properties/datasets_collection"></a>**`datasets_collection`** *(string)*: The name of the database collection for datasets. Default: `"datasets"`.
 - <a id="properties/upload_boxes_collection"></a>**`upload_boxes_collection`** *(string)*: The name of the database collection for upload boxes. Default: `"uploadBoxes"`.
 - <a id="properties/work_packages_collection"></a>**`work_packages_collection`** *(string)*: The name of the database collection for work packages. Default: `"workPackages"`.
-- <a id="properties/alt_accessions_collection"></a>**`alt_accessions_collection`** *(string)*: The name of the database collection for file accession maps. Default: `"accessionMaps"`.
+- <a id="properties/accession_maps_collection"></a>**`accession_maps_collection`** *(string)*: The name of the database collection for file accession maps. Default: `"accessionMaps"`.
 - <a id="properties/work_package_valid_days"></a>**`work_package_valid_days`** *(integer)*: How many days a work package (and its access token) stays valid. Default: `30`.
 - <a id="properties/work_package_signing_key"></a>**`work_package_signing_key`** *(string, format: password, required and write-only)*: The private key for signing work order tokens.
 
@@ -325,11 +325,15 @@ The service requires the following configuration parameters:
   "research-data-upload-boxes"
   ```
 
-- <a id="properties/alt_accession_topic"></a>**`alt_accession_topic`** *(string, required)*: The name of the topic used for AltAccession events.
+- <a id="properties/accession_map_topic"></a>**`accession_map_topic`** *(string, required)*: The name of the topic used for file accession map events.
 
   Examples:
   ```json
-  "alt-accessions"
+  "accession-maps"
+  ```
+
+  ```json
+  "file-accession-maps"
   ```
 
 - <a id="properties/dataset_change_topic"></a>**`dataset_change_topic`** *(string, required)*: Name of the topic announcing, among other things, the list of files included in a new dataset.

--- a/config_schema.json
+++ b/config_schema.json
@@ -84,10 +84,10 @@
       "title": "Work Packages Collection",
       "type": "string"
     },
-    "alt_accessions_collection": {
+    "accession_maps_collection": {
       "default": "accessionMaps",
       "description": "The name of the database collection for file accession maps",
-      "title": "Alt Accessions Collection",
+      "title": "Accession Maps Collection",
       "type": "string"
     },
     "work_package_valid_days": {
@@ -328,12 +328,13 @@
       "title": "Research Data Upload Box Topic",
       "type": "string"
     },
-    "alt_accession_topic": {
-      "description": "The name of the topic used for AltAccession events",
+    "accession_map_topic": {
+      "description": "The name of the topic used for file accession map events",
       "examples": [
-        "alt-accessions"
+        "accession-maps",
+        "file-accession-maps"
       ],
-      "title": "Alt Accession Topic",
+      "title": "Accession Map Topic",
       "type": "string"
     },
     "dataset_change_topic": {
@@ -574,7 +575,7 @@
     "migration_wait_sec",
     "kafka_servers",
     "research_data_upload_box_topic",
-    "alt_accession_topic",
+    "accession_map_topic",
     "dataset_change_topic",
     "dataset_deletion_type",
     "dataset_upsertion_type",

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,6 +1,6 @@
 access_url: http://127.0.0.1:8080/
-alt_accession_topic: alt-accessions
-alt_accessions_collection: accessionMaps
+accession_map_topic: file-accession-mappings
+accession_maps_collection: accessionMaps
 api_root_path: ''
 auth_algs:
 - ES256

--- a/src/wps/adapters/inbound/event_sub.py
+++ b/src/wps/adapters/inbound/event_sub.py
@@ -23,17 +23,16 @@ from uuid import UUID
 from ghga_event_schemas import pydantic_ as event_schemas
 from ghga_event_schemas.configs import (
     DatasetEventsConfig,
+    FileAccessionMappingEventsConfig,
     ResearchDataUploadBoxEventsConfig,
 )
 from ghga_event_schemas.validation import get_validated_payload
 from hexkit.custom_types import Ascii, JsonObject
 from hexkit.protocols.daosub import DaoSubscriberProtocol
 from hexkit.protocols.eventsub import EventSubscriberProtocol
-from pydantic import Field
 
 from wps.constants import TRACER
 from wps.core.models import (
-    AltAccession,
     Dataset,
     DatasetFile,
     ResearchDataUploadBoxBasics,
@@ -42,8 +41,6 @@ from wps.core.models import (
 from wps.ports.inbound.repository import WorkPackageRepositoryPort
 
 __all__ = [
-    "FILE_ID_TYPE",
-    "AltAccessionOutboxTranslator",
     "EventSubTranslator",
     "EventSubTranslatorConfig",
     "OutboxSubConfig",
@@ -52,24 +49,18 @@ __all__ = [
 
 log = logging.getLogger(__name__)
 
-FILE_ID_TYPE = "FILE_ID"
-
 
 class EventSubTranslatorConfig(DatasetEventsConfig):
     """Config for dataset creation related events."""
 
 
-class OutboxSubConfig(ResearchDataUploadBoxEventsConfig):
+class OutboxSubConfig(
+    FileAccessionMappingEventsConfig, ResearchDataUploadBoxEventsConfig
+):
     """Config for listening to events carrying state updates for UploadBox objects
 
     The event types are hardcoded by `hexkit`.
     """
-
-    alt_accession_topic: str = Field(
-        default=...,
-        description="The name of the topic used for AltAccession events",
-        examples=["alt-accessions"],
-    )
 
 
 class EventSubTranslator(EventSubscriberProtocol):
@@ -199,11 +190,13 @@ class RDUBOutboxTranslator(DaoSubscriberProtocol):
             await self._repository.delete_upload_box(UUID(resource_id))
 
 
-class AltAccessionOutboxTranslator(DaoSubscriberProtocol[AltAccession]):
-    """An outbox subscriber event translator for AltAccession outbox events."""
+class AccessionMapOutboxTranslator(
+    DaoSubscriberProtocol[event_schemas.FileAccessionMapping]
+):
+    """An outbox subscriber event translator for AccessionMap outbox events."""
 
     event_topic: str
-    dto_model = AltAccession
+    dto_model = event_schemas.FileAccessionMapping
 
     def __init__(
         self,
@@ -212,26 +205,21 @@ class AltAccessionOutboxTranslator(DaoSubscriberProtocol[AltAccession]):
         work_package_repository: WorkPackageRepositoryPort,
     ):
         """Initialize the outbox subscriber"""
-        self.event_topic = config.alt_accession_topic
+        self.event_topic = config.accession_map_topic
         self._repository = work_package_repository
 
-    @TRACER.start_as_current_span("AltAccessionOutboxTranslator.changed")
-    async def changed(self, resource_id: str, update: AltAccession) -> None:
-        """Process an AltAccession event."""
-        if update.type == FILE_ID_TYPE:
-            log.info(
-                "Received upsertion outbox event for AltAccession for accession %s.",
-                resource_id,
-            )
-            await self._repository.store_accession_map(accession_map=update)
-        else:
-            log.info(
-                "Ignoring upsertion event for %s-type AltAccession for %s.",
-                update.type,
-                resource_id,
-            )
+    @TRACER.start_as_current_span("AccessionMapOutboxTranslator.changed")
+    async def changed(
+        self, resource_id: str, update: event_schemas.FileAccessionMapping
+    ) -> None:
+        """Process an AccessionMap event."""
+        log.info(
+            "Received upsertion outbox event for AccessionMap for accession %s.",
+            update.accession,
+        )
+        await self._repository.store_accession_map(accession_map=update)
 
-    @TRACER.start_as_current_span("AltAccessionOutboxTranslator.deleted")
+    @TRACER.start_as_current_span("AccessionMapOutboxTranslator.deleted")
     async def deleted(self, resource_id: str) -> None:
         """Delete the mapping for a given accession"""
         log.info(

--- a/src/wps/adapters/outbound/dao.py
+++ b/src/wps/adapters/outbound/dao.py
@@ -15,6 +15,7 @@
 
 """DAO translators for accessing the database."""
 
+from ghga_event_schemas import pydantic_ as event_schemas
 from hexkit.protocols.dao import DaoFactoryProtocol
 
 from wps.core import models
@@ -74,7 +75,7 @@ async def get_accession_map_dao(
 ) -> AccessionMapDaoPort:
     """Setup the DAO using the specified provider of the DaoFactoryProtocol."""
     return await dao_factory.get_dao(
-        name=config.alt_accessions_collection,
-        dto_model=models.AltAccession,
-        id_field="pid",
+        name=config.accession_maps_collection,
+        dto_model=event_schemas.FileAccessionMapping,
+        id_field="accession",
     )

--- a/src/wps/core/models.py
+++ b/src/wps/core/models.py
@@ -36,7 +36,6 @@ from pydantic import (
 from wps.core.crypt import validate_public_key
 
 __all__ = [
-    "AltAccession",
     "BaseWorkOrderToken",
     "BoxWithExpiration",
     "CloseFileWorkOrder",
@@ -361,26 +360,3 @@ class UploadWorkOrderTokenRequest(BaseModel):
         elif self.work_type != "create" and not self.file_id:
             raise ValueError("File ID is required for UPLOAD, CLOSE, DELETE work types")
         return self
-
-
-class AltAccession(BaseModel):
-    """Stores alternative accessions referencing a primary accession."""
-
-    id: str = Field(..., description="The UUID4 file identifier used by file services")
-    pid: str = Field(
-        ..., description="The public-facing permanent accession number for the file"
-    )
-    type: str = Field(
-        ...,
-        description=(
-            "An enumerated string describing the type of accession. WPS is only"
-            + " interested in AltAccessions where the type is 'FILE_ID'."
-        ),
-    )
-    created: UTCDatetime = Field(
-        ...,
-        description=(
-            "The timestamp for when the AltAccession was originally created"
-            + " in the GHGA Registry Service"
-        ),
-    )

--- a/src/wps/core/repository.py
+++ b/src/wps/core/repository.py
@@ -22,6 +22,7 @@ from datetime import timedelta
 from typing import cast
 from uuid import UUID
 
+from ghga_event_schemas import pydantic_ as event_schemas
 from ghga_service_commons.auth.ghga import AuthContext
 from ghga_service_commons.utils.crypt import encrypt
 from ghga_service_commons.utils.utc_dates import UTCDatetime
@@ -31,7 +32,6 @@ from pydantic import UUID4, Field, SecretStr
 from pydantic_settings import BaseSettings
 
 from wps.core.models import (
-    AltAccession,
     BoxWithExpiration,
     CloseFileWorkOrder,
     CreateFileWorkOrder,
@@ -81,7 +81,7 @@ class WorkPackageConfig(BaseSettings):
         "workPackages",
         description="The name of the database collection for work packages",
     )
-    alt_accessions_collection: str = Field(
+    accession_maps_collection: str = Field(
         "accessionMaps",
         description="The name of the database collection for file accession maps",
     )
@@ -457,7 +457,7 @@ class WorkPackageRepository(WorkPackageRepositoryPort):
             log.error(mapping_error, extra=extra)
             raise mapping_error from err
         else:
-            file_id = UUID(accession_map.id)
+            file_id = accession_map.file_id
 
         wot = DownloadWorkOrder(
             file_id=file_id,
@@ -679,13 +679,15 @@ class WorkPackageRepository(WorkPackageRepositoryPort):
             upload_boxes_with_expiration.append(box_with_expiration)
         return upload_boxes_with_expiration
 
-    async def store_accession_map(self, *, accession_map: AltAccession) -> None:
-        """Store an accession map in the database using a FILE_ID-type AltAccession"""
+    async def store_accession_map(
+        self, *, accession_map: event_schemas.FileAccessionMapping
+    ) -> None:
+        """Store an accession map in the database."""
         await self._accession_map_dao.upsert(accession_map)
         log.info(
             "Upserted accession map for accession %s, file ID %s.",
-            accession_map.pid,
-            accession_map.id,
+            accession_map.accession,
+            accession_map.file_id,
         )
 
     async def delete_accession_map(self, *, accession: str) -> None:

--- a/src/wps/ports/inbound/repository.py
+++ b/src/wps/ports/inbound/repository.py
@@ -18,11 +18,11 @@
 
 from abc import ABC, abstractmethod
 
+from ghga_event_schemas import pydantic_ as event_schemas
 from ghga_service_commons.auth.ghga import AuthContext
 from pydantic import UUID4
 
 from wps.core.models import (
-    AltAccession,
     BoxWithExpiration,
     Dataset,
     DatasetWithExpiration,
@@ -174,8 +174,10 @@ class WorkPackageRepositoryPort(ABC):
         """
 
     @abstractmethod
-    async def store_accession_map(self, *, accession_map: AltAccession) -> None:
-        """Store an accession map in the database using a FILE_ID-type AltAccession"""
+    async def store_accession_map(
+        self, *, accession_map: event_schemas.FileAccessionMapping
+    ) -> None:
+        """Store an accession map in the database."""
 
     @abstractmethod
     async def delete_accession_map(self, *, accession: str) -> None:

--- a/src/wps/ports/outbound/dao.py
+++ b/src/wps/ports/outbound/dao.py
@@ -16,6 +16,7 @@
 
 """DAO interface for accessing the database."""
 
+from ghga_event_schemas import pydantic_ as event_schemas
 from hexkit.protocols.dao import Dao, ResourceNotFoundError
 
 from wps.core import models
@@ -32,4 +33,4 @@ __all__ = [
 DatasetDaoPort = Dao[models.Dataset]
 UploadBoxDaoPort = Dao[models.ResearchDataUploadBoxBasics]
 WorkPackageDaoPort = Dao[models.WorkPackage]
-AccessionMapDaoPort = Dao[models.AltAccession]
+AccessionMapDaoPort = Dao[event_schemas.FileAccessionMapping]

--- a/src/wps/prepare.py
+++ b/src/wps/prepare.py
@@ -29,7 +29,7 @@ from hexkit.providers.akafka import (
 from hexkit.providers.mongodb import MongoDbDaoFactory
 
 from wps.adapters.inbound.event_sub import (
-    AltAccessionOutboxTranslator,
+    AccessionMapOutboxTranslator,
     EventSubTranslator,
     RDUBOutboxTranslator,
 )
@@ -148,14 +148,14 @@ async def prepare_consumer(
         rdub_outbox_translator = RDUBOutboxTranslator(
             config=config, work_package_repository=work_package_repository
         )
-        alt_accession_outbox_translator = AltAccessionOutboxTranslator(
+        accession_map_outbox_translator = AccessionMapOutboxTranslator(
             config=config, work_package_repository=work_package_repository
         )
         translator = ComboTranslator(
             translators=[
                 event_sub_translator,
                 rdub_outbox_translator,
-                alt_accession_outbox_translator,
+                accession_map_outbox_translator,
             ]
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,11 +52,11 @@ def mongodb_populated_fixture(
     dataset_collection.insert_one(dataset)
 
     # Insert file accession maps into database
-    alt_accessions_collection = database.get_collection(
-        config.alt_accessions_collection
+    accession_maps_collection = database.get_collection(
+        config.accession_maps_collection
     )
     for accession_map in FILE_ACCESSION_MAP_DOCS:
-        alt_accessions_collection.insert_one(accession_map)
+        accession_maps_collection.insert_one(accession_map)
 
     # Insert an upload box into the database
     upload_box = {

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -16,24 +16,21 @@
 
 """Sample datasets for testing."""
 
-from datetime import UTC, datetime
+from uuid import UUID
 
 from ghga_event_schemas.pydantic_ import (
+    FileAccessionMapping,
     MetadataDatasetFile,
     MetadataDatasetID,
     MetadataDatasetOverview,
     MetadataDatasetStage,
 )
 
-from wps.adapters.inbound.event_sub import FILE_ID_TYPE
 from wps.core.models import (
-    AltAccession,
     Dataset,
     DatasetFile,
     WorkPackageType,
 )
-
-_CREATED = datetime(2024, 1, 1, tzinfo=UTC)
 
 __all__ = [
     "DATASET",
@@ -84,28 +81,13 @@ DATASET_UPSERTION_EVENT = MetadataDatasetOverview(
 )
 
 FILE_ACCESSION_MAP_DOCS: list[dict] = [
-    {
-        "_id": "GHGAF01",
-        "id": "ed42650f-a683-4300-ad41-6d13e33b45eb",
-        "type": "FILE_ID",
-        "created": _CREATED,
-    },
-    {
-        "_id": "GHGAF02",
-        "id": "abeffa71-37d0-4a4b-8b6d-c66e8a15af41",
-        "type": "FILE_ID",
-        "created": _CREATED,
-    },
-    {
-        "_id": "GHGAF03",
-        "id": "d1038bd8-7a04-40ba-8a3d-9eb4146b02e9",
-        "type": "FILE_ID",
-        "created": _CREATED,
-    },
+    {"_id": "GHGAF01", "file_id": UUID("ed42650f-a683-4300-ad41-6d13e33b45eb")},
+    {"_id": "GHGAF02", "file_id": UUID("abeffa71-37d0-4a4b-8b6d-c66e8a15af41")},
+    {"_id": "GHGAF03", "file_id": UUID("d1038bd8-7a04-40ba-8a3d-9eb4146b02e9")},
 ]
 
 FILE_ACCESSION_MAPS = [
-    AltAccession(pid=doc["_id"], id=doc["id"], type=FILE_ID_TYPE, created=_CREATED)
+    FileAccessionMapping(accession=doc["_id"], file_id=doc["file_id"])
     for doc in FILE_ACCESSION_MAP_DOCS
 ]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -229,7 +229,7 @@ async def test_make_download_work_order_token(
     assert wot_dict.pop("exp") - wot_dict.pop("iat") == 30
     assert wot_dict == {
         "work_type": "download",
-        "file_id": FILE_ACCESSION_MAPS[2].id,
+        "file_id": str(FILE_ACCESSION_MAPS[2].file_id),
         "accession": "GHGAF03",
         "user_public_crypt4gh_key": user_public_crypt4gh_key,
     }

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -29,7 +29,7 @@ from hexkit.providers.mongodb.testutils import MongoDbFixture
 from hexkit.utils import now_utc_ms_prec
 
 from wps.config import Config
-from wps.core.models import AltAccession, ResearchDataUploadBoxBasics
+from wps.core.models import ResearchDataUploadBoxBasics
 from wps.prepare import Consumer, prepare_consumer
 
 from .fixtures import (  # noqa: F401
@@ -307,22 +307,22 @@ async def test_rudb_outbox_consumer(config: Config, kafka: KafkaFixture):
 
 
 async def test_accession_outbox_consumer(config: Config, kafka: KafkaFixture):
-    """Test consuming an 'upserted' & 'deleted' AltAccession event in the outbox consumer."""
+    """Test consuming an 'upserted' & 'deleted' accession map event in the outbox consumer."""
     # Create a mock repository to track calls
     mock_repository = AsyncMock()
-    alt_accession_payload = FILE_ACCESSION_MAPS[0].model_dump(mode="json")
+    accession_map_event_payload = FILE_ACCESSION_MAPS[0].model_dump(mode="json")
     # Create a consumer with the mock repository
     async with prepare_consumer(
         config=config, work_package_repo_override=mock_repository
     ) as consumer:
         subscriber = consumer.event_subscriber
 
-        # Publish an outbox 'upserted' event for an AltAccession
+        # Publish an outbox 'upserted' event for an accession map
         await kafka.publish_event(
-            payload=alt_accession_payload,
-            topic=config.alt_accession_topic,
+            payload=accession_map_event_payload,
+            topic=config.accession_map_topic,
             type_="upserted",
-            key=FILE_ACCESSION_MAPS[0].pid,
+            key="",
         )
 
         # Process the event
@@ -336,7 +336,7 @@ async def test_accession_outbox_consumer(config: Config, kafka: KafkaFixture):
         # Publish an outbox 'deleted' event
         await kafka.publish_event(
             payload={},
-            topic=config.alt_accession_topic,
+            topic=config.accession_map_topic,
             type_="deleted",
             key="GHGAF01",
         )
@@ -348,31 +348,3 @@ async def test_accession_outbox_consumer(config: Config, kafka: KafkaFixture):
         mock_repository.delete_accession_map.assert_called_once_with(
             accession="GHGAF01"
         )
-
-
-async def test_non_file_id_alt_accession_event_is_ignored(
-    config: Config, kafka: KafkaFixture
-):
-    """Test that 'upserted' AltAccession events with a type other than FILE_ID are ignored."""
-    mock_repository = AsyncMock()
-    non_file_id_accession = AltAccession(
-        pid="GHGAF01",
-        id="ed42650f-a683-4300-ad41-6d13e33b45eb",
-        type="EGA",
-        created=FILE_ACCESSION_MAPS[0].created,
-    )
-    async with prepare_consumer(
-        config=config, work_package_repo_override=mock_repository
-    ) as consumer:
-        subscriber = consumer.event_subscriber
-
-        await kafka.publish_event(
-            payload=non_file_id_accession.model_dump(mode="json"),
-            topic=config.alt_accession_topic,
-            type_="upserted",
-            key="GHGAF01",
-        )
-
-        await asyncio.wait_for(subscriber.run(forever=False), timeout=TIMEOUT)
-
-        mock_repository.store_accession_map.assert_not_called()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -182,7 +182,7 @@ async def test_work_package_and_token_creation(
     assert wot_claims.pop("exp") - wot_claims.pop("iat") == valid_days
     assert wot_claims == {
         "work_type": package.type.value,
-        "file_id": FILE_ACCESSION_MAPS[2].id,
+        "file_id": str(FILE_ACCESSION_MAPS[2].file_id),
         "accession": "GHGAF03",
         "user_public_crypt4gh_key": user_public_crypt4gh_key,
     }
@@ -232,7 +232,7 @@ async def test_work_package_and_token_creation(
     assert wot_claims.pop("exp") - wot_claims.pop("iat") == valid_days
     assert wot_claims == {
         "work_type": package.type.value,
-        "file_id": FILE_ACCESSION_MAPS[0].id,
+        "file_id": str(FILE_ACCESSION_MAPS[0].file_id),
         "accession": "GHGAF01",
         "user_public_crypt4gh_key": user_public_crypt4gh_key,
     }
@@ -477,7 +477,7 @@ async def test_accession_maps(
     config: Config, repository: WorkPackageRepository, mongodb: MongoDbFixture
 ):
     """Test storing and deleting accession maps"""
-    collection = mongodb.client[config.db_name][config.alt_accessions_collection]
+    collection = mongodb.client[config.db_name][config.accession_maps_collection]
 
     # First verify nothing is in the collection
     assert not collection.find().to_list()


### PR DESCRIPTION
We decided not to use AltAccessions to communicate file-accession mappings, so this PR reverts the WPS to FileAccessionMappings once more.